### PR TITLE
feat:(infra) -  add GitHub Actions workflow for Docker image release and create production Docker Compose file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+    workflow_dispatch:
+
+jobs:
+    build-and-push:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        if: github.actor == 'mikicvi'
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Build and push frontend image
+              run: |
+                  docker buildx build --platform linux/amd64,linux/arm64 -t mikicv/schedulrai-frontend:latest -t mikicv/schedulrai-frontend:${{ github.run_id }} -f Dockerfile.frontend . --push
+
+            - name: Build and push backend image
+              run: |
+                  docker buildx build --platform linux/amd64,linux/arm64 -t mikicv/schedulrai-backend:latest -t mikicv/schedulrai-backend:${{ github.run_id }} -f Dockerfile.backend . --push
+
+            - name: Build and push ollama image
+              run: |
+                  docker buildx build --platform linux/amd64,linux/arm64 -t mikicv/schedulrai-ollama:latest -t mikicv/schedulrai-ollama:${{ github.run_id }} -f Dockerfile.ollama . --push

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,62 @@
+services:
+    chroma:
+        image: chromadb/chroma:latest
+        ports:
+            - '8000:8000'
+        env_file: .env
+        environment:
+            - IS_PERSISTENT=TRUE
+        networks:
+            - schedulrai
+        container_name: chroma
+        volumes:
+            - .chroma_volume:/chroma/chroma
+
+    ollama:
+        image: mikicv/schedulrai-ollama:latest
+        ports:
+            - '11434:11434'
+        volumes:
+            - .ollama_volume:/root/.ollama
+        container_name: ollama
+        pull_policy: always
+        tty: true
+        restart: always
+        networks:
+            - schedulrai
+        env_file: ./docker/ollama.env
+
+    backend:
+        image: mikicv/schedulrai-backend:latest
+        ports:
+            - '3000:3000'
+        container_name: backend
+        pull_policy: always
+        tty: true
+        restart: always
+        networks:
+            - schedulrai
+        env_file: .env
+        volumes:
+            - .sqlite_volume:/app/data
+        environment:
+            - CHROMA_SERVER_HOST=chroma
+            - OLLAMA_API_BASE=ollama
+
+    frontend:
+        image: mikicv/schedulrai-frontend:latest
+        ports:
+            - '80:80'
+        container_name: frontend
+        networks:
+            - schedulrai
+        depends_on:
+            - backend
+
+networks:
+    schedulrai:
+        driver: bridge
+volumes:
+    ollama_volume:
+    chroma_volume:
+    sqlite_volume:

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Get username from env
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+
+# Define variables
+FRONTEND_IMAGE_NAME="$DOCKER_USERNAME/schedulrai-frontend"
+BACKEND_IMAGE_NAME="$DOCKER_USERNAME/schedulrai-backend"
+OLLAMA_IMAGE_NAME="$DOCKER_USERNAME/schedulrai-ollama"
+VERSION_TAG=$(date +%Y%m%d%H%M)
+
+# Create and use a new builder instance
+docker buildx create --use
+
+# Build and push frontend image for both x86 and ARM64
+echo "Building and pushing frontend image..."
+docker buildx build --platform linux/amd64,linux/arm64 -t $FRONTEND_IMAGE_NAME:latest -t $FRONTEND_IMAGE_NAME:$VERSION_TAG -f Dockerfile.frontend . --push
+
+# Build and push backend image for both x86 and ARM64
+echo "Building and pushing backend image..."
+docker buildx build --platform linux/amd64,linux/arm64 -t $BACKEND_IMAGE_NAME:latest -t $BACKEND_IMAGE_NAME:$VERSION_TAG -f Dockerfile.backend . --push
+
+# Build and push ollama image for both x86 and ARM64
+echo "Building and pushing ollama image..."
+docker buildx build --platform linux/amd64,linux/arm64 -t $OLLAMA_IMAGE_NAME:latest -t $OLLAMA_IMAGE_NAME:$VERSION_TAG -f Dockerfile.ollama . --push
+
+echo "Release completed successfully!"


### PR DESCRIPTION
- Implements docker image release automation, and adds shell script to achieve the same

### Automation and CI/CD:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R38): Added a GitHub Actions workflow to automate the build and push of Docker images for the frontend, backend, and ollama components. The workflow is triggered manually and runs only if the GitHub actor is 'mikicvi'.
* [`release.sh`](diffhunk://#diff-8bc94a3006768345d17c827c0bb5840e6e4daee6de1c2b1ea672f53f162d171dR1-R33): Created a release script that builds and pushes Docker images for the frontend, backend, and ollama components to Docker Hub, supporting both x86 and ARM64 architectures. The script uses environment variables for Docker Hub credentials and tags images with the current date and time.

### Production Environment Configuration:

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R62): Defined a Docker Compose configuration for the production environment, including services for `chroma`, `ollama`, `backend`, and `frontend`. Each service is configured with appropriate images, ports, volumes, environment variables, and network settings.