### PR TITLE
fix: update database path and fix line feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ COMPOSE_PROJECT_NAME=schedulrai
 # Ollama Configuration
 OLLAMA_API_BASE=127.0.0.1
 OLLAMA_PORT=11434
-LLM_MODEL=llama3.2:3b-instruct-q5_K_M
+LLM_MODEL='llama3.2:3b-instruct-q5_K_M'
 LLM_EMBED_MODEL=nomic-embed-text
 
 # Server Configuration

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -58,7 +58,7 @@ const initializeApp = async () => {
 			resave: false,
 			saveUninitialized: false,
 			store: new SQLiteStoreSession({
-				db: process.env.DB_PATH || 'data/db.sqlite3',
+				db: process.env.DB_PATH || 'app/data/db.sqlite3',
 				dir: '/',
 				table: 'sessions',
 			}),

--- a/backend/src/middlewares/db.ts
+++ b/backend/src/middlewares/db.ts
@@ -4,7 +4,7 @@ import { resolve, dirname } from 'path';
 import logger from '../utils/logger';
 import('../models/associations'); // Relationships for the models
 
-const dbPath = process.env.DB_PATH || resolve('data/db.sqlite3');
+const dbPath = process.env.DB_PATH || resolve('app/data/db.sqlite3');
 
 // Ensure data directory exists
 mkdirSync(dirname(dbPath), { recursive: true });

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
         restart: always
         networks:
             - schedulrai
-        env_file: ./docker/ollama.env
+        env_file: .env
 
     backend:
         image: mikicv/schedulrai-backend:latest

--- a/docker/ollama.env
+++ b/docker/ollama.env
@@ -1,2 +1,2 @@
-LLM_MODEL=llama3.2:3b-instruct-q5_K_M
+LLM_MODEL='llama3.2:3b-instruct-q5_K_M'
 LLM_EMBED_MODEL=nomic-embed-text


### PR DESCRIPTION
Environment configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL14-R14): Changed the `LLM_MODEL` value to be enclosed in single quotes.
* [`docker/ollama.env`](diffhunk://#diff-0b91164b62ba7bacee0654bda784ad5ac4c4e57a8f568fe2a1ea74bb99898b66L1-R1): Changed the `LLM_MODEL` value to be enclosed in single quotes.
* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L27-R27): Updated the `env_file` path to use `.env` instead of `./docker/ollama.env`.

Database path updates:

* [`backend/src/app.ts`](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fL61-R61): Updated the database path to `app/data/db.sqlite3`.
* [`backend/src/middlewares/db.ts`](diffhunk://#diff-9a246097f02e47af83ca3c1175ce620df235b4bd02c775cad01618a45d6b3a94L7-R7): Updated the database path to `app/data/db.sqlite3`.