### PR TITLE
fix: update database path resolution for session store and middleware for cross os

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import authRoutes from './routes/authRoutes';
 import { initializeDatabase } from './middlewares/db';
 import SQLiteStore from 'connect-sqlite3';
 import rateLimit from 'express-rate-limit';
+import { resolve } from 'path';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -51,15 +52,14 @@ const initializeApp = async () => {
 	app.use(cors(corsOptions));
 	app.use(express.json());
 	app.use(express.urlencoded({ extended: true }));
-
 	app.use(
 		session({
 			secret: process.env.AUTH_SECRET || 'default_secret',
 			resave: false,
 			saveUninitialized: false,
 			store: new SQLiteStoreSession({
-				db: process.env.DB_PATH || 'app/data/db.sqlite3',
-				dir: '/',
+				db: process.env.DB_PATH || resolve('data/db.sqlite3'),
+				dir: '.',
 				table: 'sessions',
 			}),
 		})

--- a/backend/src/middlewares/db.ts
+++ b/backend/src/middlewares/db.ts
@@ -4,7 +4,7 @@ import { resolve, dirname } from 'path';
 import logger from '../utils/logger';
 import('../models/associations'); // Relationships for the models
 
-const dbPath = process.env.DB_PATH || resolve('app/data/db.sqlite3');
+const dbPath = process.env.DB_PATH || resolve('data/db.sqlite3');
 
 // Ensure data directory exists
 mkdirSync(dirname(dbPath), { recursive: true });


### PR DESCRIPTION
Path resolution improvements:
- Fix for middleware: remove wrong `/app` path
- Fix for session store: fix path, and user resolve() for better cross-os path management

### Tested
- Linux
- Mac
- Windows