### PR TITLE
feat(frontend & backend): Implement User profile, other bits & pieces

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import pipelineRoutes from './routes/pipelineRoutes';
 import authRoutes from './routes/authRoutes';
 import emailRoutes from './routes/emailRoutes';
 import calendarRoutes from './routes/calendarRoutes';
+import profileRoutes from './routes/profileRoutes';
 import express from 'express';
 import session from 'express-session';
 import passport from './middlewares/passport';
@@ -100,6 +101,7 @@ const initializeApp = async () => {
 	app.use(baseApiRoute, authRoutes);
 	app.use(baseApiRoute, emailRoutes);
 	app.use(baseApiRoute, calendarRoutes);
+	app.use(baseApiRoute, profileRoutes);
 
 	return app;
 };

--- a/backend/src/routes/profileRoutes.ts
+++ b/backend/src/routes/profileRoutes.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+import { ensureAuthenticated } from '../middlewares/auth';
+import { getAllEvents, getCalendarById, getUserById, updateUser } from '../services/dbServices';
+import { sequelize } from '../middlewares/db';
+import Event from '../models/event.model';
+
+const router = Router();
+
+// Update user profile
+router.put('/profile', ensureAuthenticated, async (req, res) => {
+	try {
+		const { username, email, firstName, lastName, userSettings } = req.body;
+
+		const [_, updatedUser] = await updateUser(req.user.id, {
+			username,
+			email,
+			firstName,
+			lastName,
+			userSettings,
+		});
+
+		res.json({
+			success: true,
+			user: updatedUser[0],
+		});
+	} catch (error) {
+		res.status(400).json({
+			success: false,
+			message: error.message,
+		});
+	}
+});
+
+// Get user profile
+router.get('/profile', ensureAuthenticated, async (req, res) => {
+	try {
+		const user = await getUserById(req.user.id);
+		if (!user) {
+			res.status(404).json({
+				success: false,
+				message: 'User not found',
+			});
+		} else {
+			const filteredUser = {
+				id: user.id,
+				username: user.username,
+				email: user.email,
+				firstName: user.firstName,
+				lastName: user.lastName,
+				userSettings: user.userSettings,
+			};
+			res.json({
+				success: true,
+				user: filteredUser,
+			});
+		}
+	} catch (error) {
+		res.status(400).json({
+			success: false,
+			message: error.message,
+		});
+	}
+});
+
+// Get user stats
+router.get('/profile/stats', ensureAuthenticated, async (req, res) => {
+	try {
+		const user = await getUserById(req.user.id);
+		if (!user) {
+			res.status(404).json({
+				success: false,
+				message: 'User not found',
+			});
+		} else {
+			const calendar = await getCalendarById(user.calendarId);
+			if (!calendar) {
+				res.status(404).json({
+					success: false,
+					message: 'Calendar not found',
+				});
+			} else {
+				const events = await getAllEvents(calendar.id);
+
+				// Calculate events per month using strftime for SQLite
+				const eventsPerMonth = await Event.findAll({
+					attributes: [
+						[sequelize.fn('strftime', '%Y-%m', sequelize.col('startTime')), 'month'],
+						[sequelize.fn('COUNT', sequelize.col('id')), 'count'],
+					],
+					where: { calendarId: calendar.id },
+					group: [sequelize.fn('strftime', '%Y-%m', sequelize.col('startTime'))],
+					order: [[sequelize.fn('strftime', '%Y-%m', sequelize.col('startTime')), 'ASC']],
+				});
+
+				res.json({
+					success: true,
+					stats: {
+						totalEvents: events.length,
+						totalCalendars: 1, // Only one calendar per user
+						joinedDate: user.createdAt,
+						eventsPerMonth: eventsPerMonth.map((event) => ({
+							month: event.get('month'),
+							count: event.get('count'),
+						})),
+					},
+				});
+			}
+		}
+	} catch (error) {
+		res.status(400).json({
+			success: false,
+			message: error.message,
+		});
+	}
+});
+
+export default router;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-router-dom": "^6.26.2",
+        "recharts": "^2.15.1",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.1"
@@ -3186,6 +3187,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/date-arithmetic": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/date-arithmetic/-/date-arithmetic-4.1.4.tgz",
@@ -3876,6 +3940,127 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-arithmetic": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
@@ -3914,6 +4099,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4279,11 +4470,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4609,6 +4815,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -5582,6 +5797,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -5604,6 +5834,22 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5622,6 +5868,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+      "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
@@ -5998,6 +6282,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6195,6 +6485,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^6.26.2",
+    "recharts": "^2.15.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.1"

--- a/frontend/src/app/Layout.tsx
+++ b/frontend/src/app/Layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children, breadcrumbItems }: LayoutProps) {
 			<div className='flex h-screen w-full overflow-hidden'>
 				<AppSidebar />
 				<main className='flex-1 flex flex-col h-screen w-full overflow-hidden'>
-					<div className='flex justify-between items-center p-4 shrink-0 w-full'>
+					<div className='flex justify-between items-center p-3 shrink-0 w-full'>
 						<div className='flex items-center'>
 							<SidebarTrigger variant='outline' />
 							<Separator orientation='vertical' className='mx-4 h-6' />

--- a/frontend/src/app/Profile.tsx
+++ b/frontend/src/app/Profile.tsx
@@ -1,10 +1,52 @@
+import { useEffect } from 'react';
 import Layout from './Layout';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import ProfileForm from '@/components/ProfileForm';
+import { useUser } from '@/contexts/UserContext';
+import { useProfileStats } from '@/hooks/use-profile-stats';
+import { useProfileData } from '@/hooks/use-profile-data';
+import { AccountOverview } from '@/components/AccountOverview';
 
-export default function Profile() {
-	const breadcrumbItems = [{ title: 'Profile', href: '/profile' }, { title: 'Customise your user profile' }];
+export function Profile() {
+	const { user } = useUser();
+	const { stats, formattedEventsData, fetchStats } = useProfileStats();
+	const { profileData, fetchProfileData } = useProfileData();
+
+	useEffect(() => {
+		if (user) {
+			fetchStats();
+			fetchProfileData();
+		}
+	}, [user]);
+
 	return (
-		<Layout breadcrumbItems={breadcrumbItems}>
-			<h1> Profile </h1>
+		<Layout breadcrumbItems={[{ title: 'Profile' }]}>
+			<Card>
+				<div className='container mx-auto p-4 space-y-6'>
+					<div className='grid gap-6 md:grid-cols-2'>
+						{/* User Profile Form */}
+						<Card>
+							<CardHeader>
+								<h2 className='text-2xl font-bold'>Profile Settings</h2>
+							</CardHeader>
+							<CardContent>
+								{profileData && (
+									<ProfileForm defaultValues={profileData} onSuccess={fetchProfileData} />
+								)}
+							</CardContent>
+						</Card>
+
+						{/* Account Overview */}
+						<AccountOverview
+							stats={stats}
+							formattedEventsData={formattedEventsData}
+							hasGoogleAccount={user?.googleUser}
+						/>
+					</div>
+				</div>
+			</Card>
 		</Layout>
 	);
 }
+
+export default Profile;

--- a/frontend/src/app/SendMail.tsx
+++ b/frontend/src/app/SendMail.tsx
@@ -93,7 +93,7 @@ export default function SendMail() {
 		try {
 			emailSchema.parse({ to, subject, body });
 
-			const response = await apiFetch('http://localhost:3000/api/email/send', {
+			const response = await apiFetch('/email/send', {
 				method: 'POST',
 				body: JSON.stringify({ to, subject, body }),
 			});

--- a/frontend/src/components/AccountOverview.tsx
+++ b/frontend/src/components/AccountOverview.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { EventsPieChart } from './EventsPieChart';
+import { TrendIndicator } from './TrendIndicator';
+import { ProfileStats } from '@/hooks/use-profile-stats';
+
+interface AccountOverviewProps {
+	stats: ProfileStats;
+	formattedEventsData: Array<{ month: string; count: number; fill?: string }>;
+	hasGoogleAccount?: boolean;
+}
+
+export function AccountOverview({ stats, formattedEventsData, hasGoogleAccount }: AccountOverviewProps) {
+	const StatItem = ({ label, value }: { label: string; value: React.ReactNode }) => (
+		<div>
+			<p className='text-sm text-muted-foreground'>{label}</p>
+			<p className='font-medium'>{value}</p>
+		</div>
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<h2 className='text-2xl font-bold'>Account Overview</h2>
+			</CardHeader>
+			<CardContent className='space-y-4'>
+				<div className='grid grid-cols-2 gap-1'>
+					<div className='space-y-2'>
+						<StatItem
+							label='Member since'
+							value={stats.joinedDate ? new Date(stats.joinedDate).toLocaleDateString() : 'N/A'}
+						/>
+						<StatItem label='Total Events' value={stats.totalEvents} />
+						<StatItem label='Total Calendars' value={stats.totalCalendars} />
+					</div>
+					<div>{hasGoogleAccount && <StatItem label='Google Account Linked' value='Yes' />}</div>
+				</div>
+				{stats.eventsPerMonth.length > 0 && (
+					<EventsPieChart
+						data={formattedEventsData}
+						title='Events per Month'
+						footerContent={
+							<>
+								{stats.eventsPerMonth.length > 1 && (
+									<TrendIndicator eventsPerMonth={stats.eventsPerMonth} />
+								)}
+								<div className='leading-none text-muted-foreground'>
+									Showing total events for the last {stats.eventsPerMonth.length} month
+									{stats.eventsPerMonth.length > 1 ? 's' : ''}
+								</div>
+							</>
+						}
+					/>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/EventsPieChart.tsx
+++ b/frontend/src/components/EventsPieChart.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { Label, Pie, PieChart } from 'recharts';
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+
+interface EventsPieChartProps {
+	data: { month: string; count: number; fill?: string }[];
+	title: string;
+	description?: string;
+	footerContent: React.ReactNode;
+}
+
+export function EventsPieChart({ data, title, description, footerContent }: Readonly<EventsPieChartProps>) {
+	const chartConfig = React.useMemo(() => {
+		const config: ChartConfig = {
+			events: {
+				label: 'Events',
+			},
+		};
+
+		// Add month configurations dynamically
+		data.forEach((item) => {
+			config[item.month] = {
+				label: item.month,
+				color: item.fill,
+			};
+		});
+
+		return config;
+	}, [data]);
+
+	const totalEvents = React.useMemo(() => {
+		return data.reduce((acc, curr) => acc + curr.count, 0);
+	}, [data]);
+
+	return (
+		<Card className='flex flex-col'>
+			<CardHeader className='items-center pb-0'>
+				<CardTitle>{title}</CardTitle>
+				<CardDescription>{description}</CardDescription>
+			</CardHeader>
+			<CardContent className='flex-1 pb-0'>
+				<ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px]'>
+					<PieChart>
+						<ChartTooltip content={<ChartTooltipContent />} />
+						<Pie
+							data={data}
+							dataKey='count'
+							nameKey='month'
+							innerRadius={60}
+							strokeWidth={10}
+							outerRadius={90}
+						>
+							<Label
+								content={({ viewBox }) => {
+									if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+										return (
+											<text
+												x={viewBox.cx}
+												y={viewBox.cy}
+												textAnchor='middle'
+												dominantBaseline='middle'
+											>
+												<tspan
+													x={viewBox.cx}
+													y={viewBox.cy}
+													className='fill-foreground text-3xl font-bold'
+												>
+													{totalEvents.toLocaleString()}
+												</tspan>
+												<tspan
+													x={viewBox.cx}
+													y={(viewBox.cy || 0) + 24}
+													className='fill-muted-foreground'
+												>
+													Events
+												</tspan>
+											</text>
+										);
+									}
+								}}
+							/>
+						</Pie>
+					</PieChart>
+				</ChartContainer>
+			</CardContent>
+			<CardFooter className='flex-col gap-2 text-sm'>{footerContent}</CardFooter>
+		</Card>
+	);
+}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -19,7 +19,7 @@ const LoginForm = () => {
 		e.preventDefault();
 		setIsLoading(true);
 		try {
-			const response = await apiFetch('http://localhost:3000/api/login', {
+			const response = await apiFetch('/login', {
 				method: 'POST',
 				body: JSON.stringify({ username, password }),
 			});

--- a/frontend/src/components/Logout.tsx
+++ b/frontend/src/components/Logout.tsx
@@ -13,7 +13,7 @@ const Logout = () => {
 			if (isLoading) return;
 
 			try {
-				const response = await apiFetch('http://localhost:3000/api/logout', {
+				const response = await apiFetch('/logout', {
 					method: 'GET',
 				});
 

--- a/frontend/src/components/ProfileForm.tsx
+++ b/frontend/src/components/ProfileForm.tsx
@@ -1,161 +1,138 @@
-import { useForm, useFieldArray } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { cn } from "@/lib/utils";
-import { toast } from "@/hooks/use-toast";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Link } from "react-router-dom";
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { useApi } from '@/hooks/use-Api';
 
 const profileFormSchema = z.object({
 	username: z
 		.string()
-		.min(2, { message: "Username must be at least 2 characters." })
-		.max(30, { message: "Username must not be longer than 30 characters." }),
-	email: z.string({ required_error: "Please select an email to display." }).email(),
-	bio: z.string().max(160).min(4),
-	urls: z
-		.array(
-			z.object({
-				value: z.string().url({ message: "Please enter a valid URL." }),
-			})
-		)
+		.min(2, { message: 'Username must be at least 2 characters.' })
+		.max(30, { message: 'Username must not be longer than 30 characters.' }),
+	email: z.string().email({ message: 'Please enter a valid email address' }),
+	firstName: z.string().min(2, { message: 'First name must be at least 2 characters.' }),
+	lastName: z.string().min(2, { message: 'Last name must be at least 2 characters.' }),
+	userSettings: z
+		.object({
+			theme: z.enum(['light', 'dark', 'system']).default('system'),
+			notifications: z.boolean().default(true),
+			timezone: z.string().default('UTC'),
+		})
 		.optional(),
 });
 
 type ProfileFormValues = z.infer<typeof profileFormSchema>;
 
-const defaultValues: Partial<ProfileFormValues> = {
-	bio: "I own a computer.",
-	urls: [{ value: "https://example.com" }, { value: "http://twitter.com/example" }],
-};
+const ProfileForm = ({ defaultValues, onSuccess }: { defaultValues: ProfileFormValues; onSuccess: () => void }) => {
+	const { apiFetch } = useApi();
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
-export function ProfileForm() {
 	const form = useForm<ProfileFormValues>({
 		resolver: zodResolver(profileFormSchema),
 		defaultValues,
-		mode: "onChange",
+		mode: 'onChange',
 	});
 
-	const { fields, append } = useFieldArray({
-		name: "urls",
-		control: form.control,
-	});
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setIsSubmitting(true);
+		console.log('Form submitted with values:', form.getValues());
 
-	function onSubmit(data: ProfileFormValues) {
-		toast({
-			title: "You submitted the following values:",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">{JSON.stringify(data, null, 2)}</code>
-				</pre>
-			),
-		});
-	}
+		try {
+			const response = await apiFetch('/profile', {
+				method: 'PUT',
+				body: JSON.stringify(form.getValues()),
+			});
+
+			const data = await response.json();
+
+			if (response.ok && data.success) {
+				toast({
+					title: 'Success',
+					description: 'Profile updated successfully',
+				});
+				onSuccess();
+			} else {
+				throw new Error(data.message || 'Failed to update profile');
+			}
+		} catch (error) {
+			console.error('Submission error:', error);
+			toast({
+				title: 'Error',
+				description: error instanceof Error ? error.message : 'Failed to update profile',
+				variant: 'destructive',
+			});
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+			<form onSubmit={handleSubmit} className='space-y-8'>
 				<FormField
 					control={form.control}
-					name="username"
+					name='username'
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>Username</FormLabel>
 							<FormControl>
-								<Input placeholder="username" {...field} />
+								<Input placeholder='username' {...field} />
 							</FormControl>
-							<FormDescription>
-								This is your public display name. It can be your real name or a pseudonym. You can only
-								change this once every 30 days.
-							</FormDescription>
 							<FormMessage />
 						</FormItem>
 					)}
 				/>
 				<FormField
 					control={form.control}
-					name="email"
+					name='email'
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>Email</FormLabel>
-							<Select onValueChange={field.onChange} defaultValue={field.value}>
-								<FormControl>
-									<SelectTrigger>
-										<SelectValue placeholder="Select a verified email to display" />
-									</SelectTrigger>
-								</FormControl>
-								<SelectContent>
-									<SelectItem value="m@example.com">m@example.com</SelectItem>
-									<SelectItem value="m@google.com">m@google.com</SelectItem>
-									<SelectItem value="m@support.com">m@support.com</SelectItem>
-								</SelectContent>
-							</Select>
-							<FormDescription>
-								You can manage verified email addresses in your{" "}
-								<Link to="/settings">email settings</Link>.
-							</FormDescription>
+							<FormControl>
+								<Input placeholder='email' {...field} />
+							</FormControl>
+							<FormDescription>You can manage verified email addresses in your settings.</FormDescription>
 							<FormMessage />
 						</FormItem>
 					)}
 				/>
 				<FormField
 					control={form.control}
-					name="bio"
+					name='firstName'
 					render={({ field }) => (
 						<FormItem>
-							<FormLabel>Bio</FormLabel>
+							<FormLabel>First Name</FormLabel>
 							<FormControl>
-								<Textarea
-									placeholder="Tell us a little bit about yourself"
-									className="resize-none"
-									{...field}
-								/>
+								<Input placeholder='First Name' {...field} />
 							</FormControl>
-							<FormDescription>
-								You can <span>@mention</span> other users and organizations to link to them.
-							</FormDescription>
 							<FormMessage />
 						</FormItem>
 					)}
 				/>
-				<div>
-					{fields.map((field, index) => (
-						<FormField
-							control={form.control}
-							key={field.id}
-							name={`urls.${index}.value`}
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel className={cn(index !== 0 && "sr-only")}>URLs</FormLabel>
-									<FormDescription className={cn(index !== 0 && "sr-only")}>
-										Add links to your website, blog, or social media profiles.
-									</FormDescription>
-									<FormControl>
-										<Input {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-					))}
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						className="mt-2"
-						onClick={() => append({ value: "" })}
-					>
-						Add URL
-					</Button>
-				</div>
-				<Button type="submit">Update profile</Button>
+				<FormField
+					control={form.control}
+					name='lastName'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Last Name</FormLabel>
+							<FormControl>
+								<Input placeholder='Last Name' {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<Button type='submit' disabled={isSubmitting}>
+					{isSubmitting ? 'Updating...' : 'Update profile'}
+				</Button>
 			</form>
 		</Form>
 	);
-}
+};
 
 export default ProfileForm;

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -38,7 +38,7 @@ const Register = () => {
 		}
 
 		try {
-			const response = await apiFetch('http://localhost:3000/api/register', {
+			const response = await apiFetch('/register', {
 				method: 'POST',
 				body: JSON.stringify({
 					firstName,

--- a/frontend/src/components/TrendIndicator.tsx
+++ b/frontend/src/components/TrendIndicator.tsx
@@ -1,0 +1,29 @@
+import { TrendingDown, TrendingUp } from 'lucide-react';
+import { MonthlyEvent } from '@/hooks/use-profile-stats';
+
+interface TrendIndicatorProps {
+	eventsPerMonth: MonthlyEvent[];
+}
+
+export function TrendIndicator({ eventsPerMonth }: TrendIndicatorProps) {
+	if (eventsPerMonth.length < 2) return null;
+
+	const currentMonth = eventsPerMonth[eventsPerMonth.length - 1];
+	const previousMonth = eventsPerMonth[eventsPerMonth.length - 2];
+
+	const trend = ((currentMonth.count - previousMonth.count) / previousMonth.count) * 100;
+
+	if (trend > 0) {
+		return (
+			<div className='flex items-center gap-2 font-medium leading-none'>
+				Trending up by {trend.toFixed(1)}% this month <TrendingUp className='h-4 w-4' />
+			</div>
+		);
+	}
+
+	return (
+		<div className='flex items-center gap-2 font-medium leading-none'>
+			Trending down by {Math.abs(trend).toFixed(1)}% this month <TrendingDown className='h-4 w-4' />
+		</div>
+	);
+}

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -1,0 +1,363 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >["children"]
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: "line" | "dot" | "dashed"
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn("font-medium", labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot"
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          className
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+)
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center justify-center gap-4",
+          verticalAlign === "top" ? "pb-3" : "pt-3",
+          className
+        )}
+      >
+        {payload.map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+)
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -35,7 +35,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 			if (!mounted) return;
 
 			try {
-				const response = await apiFetch('http://localhost:3000/api/checkAuth', {
+				const response = await apiFetch('/checkAuth', {
 					credentials: 'include',
 				});
 

--- a/frontend/src/hooks/use-Api.ts
+++ b/frontend/src/hooks/use-Api.ts
@@ -38,6 +38,9 @@ export const useApi = () => {
 	const apiFetch = useCallback(
 		async (url: string, options: RequestInit = {}) => {
 			setIsLoading(true);
+			const defaultUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api';
+			// Support both absolute URLs and relative paths
+			const apiUrl = url.startsWith('http://') || url.startsWith('https://') ? url : `${defaultUrl}/${url}`;
 			try {
 				const csrfToken = await getCsrfToken();
 
@@ -49,8 +52,7 @@ export const useApi = () => {
 				if (options.body) {
 					headers.set('Content-Type', 'application/json');
 				}
-
-				const response = await fetch(url, {
+				const response = await fetch(apiUrl, {
 					...options,
 					headers,
 					credentials: 'include',
@@ -64,7 +66,7 @@ export const useApi = () => {
 					const newToken = await getCsrfToken();
 					headers.set('X-CSRF-TOKEN', newToken);
 
-					return fetch(url, {
+					return fetch(apiUrl, {
 						...options,
 						headers,
 						credentials: 'include',

--- a/frontend/src/hooks/use-backend.ts
+++ b/frontend/src/hooks/use-backend.ts
@@ -13,7 +13,7 @@ function useBackendStatus(pollInterval = 5000) {
 			if (!mounted) return;
 
 			try {
-				const response = await apiFetch('http://localhost:3000/api/checkPipelineStatus', {
+				const response = await apiFetch('/checkPipelineStatus', {
 					credentials: 'include',
 				});
 

--- a/frontend/src/hooks/use-pipeline.ts
+++ b/frontend/src/hooks/use-pipeline.ts
@@ -15,7 +15,7 @@ const usePipeline = () => {
 	const handleSubmit = async () => {
 		setLoading(true);
 		try {
-			const response = await apiFetch('http://localhost:3000/api/runPipeline', {
+			const response = await apiFetch('/runPipeline', {
 				method: 'POST',
 				body: JSON.stringify({ userInput: userInput }),
 			});

--- a/frontend/src/hooks/use-profile-data.ts
+++ b/frontend/src/hooks/use-profile-data.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { useApi } from './use-Api';
+
+export function useProfileData() {
+	const { apiFetch } = useApi();
+	const [profileData, setProfileData] = useState(null);
+
+	const fetchProfileData = async () => {
+		try {
+			const response = await apiFetch('/profile');
+			if (!response.ok) throw new Error('Failed to fetch profile data');
+
+			const data = await response.json();
+			if (data.success) {
+				setProfileData(data.user);
+			} else {
+				throw new Error(data.message);
+			}
+		} catch (error) {
+			console.error('Failed to fetch profile data:', error);
+			throw error;
+		}
+	};
+
+	return {
+		profileData,
+		fetchProfileData,
+	};
+}

--- a/frontend/src/hooks/use-profile-stats.ts
+++ b/frontend/src/hooks/use-profile-stats.ts
@@ -1,0 +1,63 @@
+import { useState, useMemo } from 'react';
+import { useApi } from './use-Api';
+import { formatMonthYear, getChartColors } from '@/lib/utils';
+
+export interface MonthlyEvent {
+	count: number;
+	month: string;
+	fill?: string;
+}
+
+export interface ProfileStats {
+	totalEvents: number;
+	totalCalendars: number;
+	joinedDate: string;
+	eventsPerMonth: MonthlyEvent[];
+}
+
+export function useProfileStats() {
+	const { apiFetch } = useApi();
+	const [stats, setStats] = useState<ProfileStats>({
+		totalEvents: 0,
+		totalCalendars: 0,
+		joinedDate: '',
+		eventsPerMonth: [],
+	});
+
+	const chartColors = getChartColors();
+
+	const formattedEventsData = useMemo(() => {
+		if (!stats.eventsPerMonth.length) return [];
+
+		const colorKeys = Object.keys(chartColors) as Array<keyof typeof chartColors>;
+
+		return stats.eventsPerMonth.map((event, index) => ({
+			...event,
+			month: formatMonthYear(event.month),
+			fill: chartColors[colorKeys[index % colorKeys.length]],
+		}));
+	}, [stats.eventsPerMonth, chartColors]);
+
+	const fetchStats = async () => {
+		try {
+			const response = await apiFetch('/profile/stats');
+			if (!response.ok) throw new Error('Failed to fetch user stats');
+
+			const data = await response.json();
+			if (data.success) {
+				setStats(data.stats);
+			} else {
+				throw new Error(data.message);
+			}
+		} catch (error) {
+			console.error('Failed to fetch user stats:', error);
+			throw error;
+		}
+	};
+
+	return {
+		stats,
+		formattedEventsData,
+		fetchStats,
+	};
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,11 +24,11 @@
 		--input: 240 5.9% 90%;
 		--ring: 240 5.9% 10%;
 		--radius: 1rem;
-		--chart-1: 12 76% 61%;
-		--chart-2: 173 58% 39%;
-		--chart-3: 197 37% 24%;
-		--chart-4: 43 74% 66%;
-		--chart-5: 27 87% 67%;
+		--chart-1: 359 2% 90%;
+		--chart-2: 240 1% 74%;
+		--chart-3: 240 1% 58%;
+		--chart-4: 240 1% 42%;
+		--chart-5: 240 2% 26%;
 		--sidebar-background: 0 0% 98%;
 		--sidebar-foreground: 240 5.3% 26.1%;
 		--sidebar-primary: 240 5.9% 10%;
@@ -62,11 +62,11 @@
 		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;
 		--ring: 240 4.9% 83.9%;
-		--chart-1: 220 70% 50%;
-		--chart-2: 160 60% 45%;
-		--chart-3: 30 80% 55%;
-		--chart-4: 280 65% 60%;
-		--chart-5: 340 75% 55%;
+		--chart-1: 359 2% 90%;
+		--chart-2: 240 1% 74%;
+		--chart-3: 240 1% 58%;
+		--chart-4: 240 1% 42%;
+		--chart-5: 240 2% 26%;
 		--sidebar-background: 240 5.9% 10%;
 		--sidebar-foreground: 240 4.8% 95.9%;
 		--sidebar-primary: 224.3 76.3% 48%;
@@ -90,13 +90,11 @@
 	}
 }
 
-
-
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
+	* {
+		@apply border-border outline-ring/50;
 	}
-  body {
-    @apply bg-background text-foreground;
+	body {
+		@apply bg-background text-foreground;
 	}
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -9,3 +9,28 @@ export const getCsrfToken = () => {
 	const csrfToken = document.cookie.split('; ').find((row) => row.startsWith('csrfToken='));
 	return csrfToken ? csrfToken.split('=')[1] : '';
 };
+
+export function formatMonthYear(monthStr: string): string {
+	try {
+		const [year, month] = monthStr.split('-');
+		const date = new Date(parseInt(year), parseInt(month) - 1); // Month is 0-indexed in JS Date
+
+		return new Intl.DateTimeFormat('en-US', {
+			month: 'long',
+			year: 'numeric',
+		}).format(date);
+	} catch (error) {
+		console.error('Error formatting month string:', error);
+		return monthStr; // Return the original string if there's an error
+	}
+}
+
+export function getChartColors() {
+	return {
+		color1: 'hsl(var(--chart-1))',
+		color2: 'hsl(var(--chart-2))',
+		color3: 'hsl(var(--chart-3))',
+		color4: 'hsl(var(--chart-4))',
+		color5: 'hsl(var(--chart-5))',
+	};
+}


### PR DESCRIPTION
## Implements #49 
#### Frontend
- Create profile component, as granular as possible (Account overview, EventPieChart, TrendingIndicator)
  - Pie chart shows no events over months, and nice trending indicator 
- Hooks to use profile data and stats
- Profile settings: Update username, email, first name, last name
	- Possibility of easily adding more items 
- Add charts from shadcn
- Refactor `use-Api` hook - apiFetch now loads backend API URL from env, or uses default
  - Supports passing in absolute and relative URL's
  - All frontend URLs changed to relative paths for better readability

#### Backend
- profileRoutes - put route to update, get route to get profile info, get route to get stats
- missing tests


<img width="1542" alt="image" src="https://github.com/user-attachments/assets/737d48dc-cfb2-40ec-90e0-cb58c29de380" />
