### PR TITLE
fix(backend & frontend): Event importance and clear notifications on logout

### DIFF
--- a/backend/src/tests/utils/colorMapping.test.ts
+++ b/backend/src/tests/utils/colorMapping.test.ts
@@ -18,9 +18,9 @@ describe('Color Mapping Utils', () => {
 	describe('googleColorToImportance', () => {
 		it.each([
 			['11', Importance.UrgentImportant, 'red'],
-			['6', Importance.UrgentImportant, 'orange'],
+			['4', Importance.UrgentImportant, 'pink'],
+			['6', Importance.UrgentNotImportant, 'orange'],
 			['5', Importance.UrgentNotImportant, 'yellow'],
-			['4', Importance.UrgentNotImportant, 'pink'],
 			['10', Importance.NotUrgentImportant, 'green'],
 			['3', Importance.NotUrgentImportant, 'purple'],
 			['2', Importance.NotUrgentImportant, 'purple'],

--- a/backend/src/utils/colorMapping.ts
+++ b/backend/src/utils/colorMapping.ts
@@ -53,10 +53,10 @@ export const importanceToGoogleColor = (importance: Importance): string => {
 export const googleColorToImportance = (colorId: string): Importance => {
 	switch (colorId) {
 		case '11':
-		case '6':
-			return Importance.UrgentImportant;
-		case '5':
 		case '4':
+			return Importance.UrgentImportant;
+		case '6':
+		case '5':
 			return Importance.UrgentNotImportant;
 		case '10':
 		case '3':

--- a/frontend/src/components/Logout.tsx
+++ b/frontend/src/components/Logout.tsx
@@ -3,10 +3,12 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from '@/hooks/use-toast';
 import { useApi } from '@/hooks/use-Api';
+import { useUser } from '@/contexts/UserContext';
 
 const Logout = () => {
 	const navigate = useNavigate();
 	const { apiFetch, isLoading } = useApi();
+	const { clearNotifications } = useUser();
 
 	useEffect(() => {
 		const performLogout = async () => {
@@ -23,6 +25,7 @@ const Logout = () => {
 
 				// Clear any stored tokens/state here
 				sessionStorage.clear();
+				clearNotifications();
 
 				toast({
 					title: 'Success',


### PR DESCRIPTION
## Adjustments to color importance mappings:
- #51 

## Backend
- Resolves a bug where, due to an incorrect colour mapping, the significance for Google users of events labeled as “Urgent Not Important” was erroneously converted to “Urgent Important” during synchronisation with Google Calendar.

## Frontend
- Resolves an issue where the next user would receive notifications from previously logged-in users.