### PR TITLE
feat(backend): trigger initial vector collection creation

### DIFF
--- a/backend/src/config/constants.ts
+++ b/backend/src/config/constants.ts
@@ -8,3 +8,5 @@ export const systemPromptMessage2 = `You are a helpful scheduling assistant expe
 export const systemPromptMessage3 = `Consider each item in the provided breakdown and sum them accurately to estimate the total time. Respond only with the format "Time: [hours].[minutes]".`;
 
 export const humanPromptMessage = `Customer request: {{context}} \n\nWhat is the estimated time?`;
+
+export const vectorCollectionName = 'SchedulrAI-KB';

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -59,7 +59,7 @@ export const register = async (req: Request, res: Response): Promise<void> => {
 		const userToCreate = { username, password, email, firstName, lastName };
 		const user = await createUser(userToCreate);
 		if (!user) {
-			res.status(500).json({ message: 'Registration failed' });
+			res.status(500).json({ message: 'Failed to create the user' });
 			return;
 		}
 

--- a/backend/src/controllers/chromaController.ts
+++ b/backend/src/controllers/chromaController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { getChromaCollection, getChromaStatus } from '../services/chromaServices';
 import logger from '../utils/logger';
+import { vectorCollectionName } from '../config/constants';
 
 export const chromaStatus = async (req: Request, res: Response): Promise<void> => {
 	try {
@@ -15,11 +16,10 @@ export const chromaStatus = async (req: Request, res: Response): Promise<void> =
 
 export const chromaCollections = async (req: Request, res: Response): Promise<void> => {
 	try {
-		const collections = await getChromaCollection('SchedulrAI-KB');
+		const collections = await getChromaCollection(vectorCollectionName);
 		res.status(200).json({ status: 'OK', collections });
 		logger.info(`|chromaCollections |: ${req.method} ${res.statusCode}`);
 	} catch (error) {
-
 		logger.error(error);
 		res.sendStatus(500);
 	}

--- a/backend/src/controllers/pipelineController.ts
+++ b/backend/src/controllers/pipelineController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { EventEmitter } from 'events';
 import logger from '../utils/logger';
 import RAGPipeline from '../services/pipelineServices';
+import { vectorCollectionName } from '../config/constants';
 
 const pipelineEmitter = new EventEmitter();
 
@@ -11,7 +12,7 @@ class PipelineController {
 	private readonly chromaUrl = `${process.env.PROTOCOL}://${process.env.CHROMA_SERVER_HOST}:${process.env.CHROMA_SERVER_PORT}`;
 	private readonly model = process.env.LLM_MODEL;
 	private readonly embeddingLLM = process.env.LLM_EMBED_MODEL;
-	private readonly collectionName = 'SchedulrAI-KB';
+	private readonly collectionName = vectorCollectionName;
 	private readonly vectorStoreProvider = 'basic';
 	private readonly vectorStoreCredentials = process.env.CHROMA_CLIENT_AUTH_CREDENTIALS;
 

--- a/backend/src/routes/knowledgeRoutes.ts
+++ b/backend/src/routes/knowledgeRoutes.ts
@@ -4,6 +4,7 @@ import { ensureAuthenticated } from '../middlewares/auth';
 import { getUserById, updateUser } from '../services/dbServices';
 import { resetChromaCollection } from '../services/chromaServices';
 import logger from '../utils/logger';
+import { vectorCollectionName } from '../config/constants';
 
 const router = Router();
 
@@ -88,7 +89,7 @@ router.post('/kb/knowledge/reset', ensureAuthenticated, async (req, res) => {
 			});
 
 			// Reset Chroma collection
-			await resetChromaCollection('SchedulrAI-KB');
+			await resetChromaCollection(vectorCollectionName);
 
 			res.json({
 				success: true,

--- a/backend/src/services/documentServices.ts
+++ b/backend/src/services/documentServices.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { ChromaClient, OllamaEmbeddingFunction } from 'chromadb';
 import { MarkdownTextSplitter, CharacterTextSplitter } from 'langchain/text_splitter';
 import logger from '../utils/logger';
+import { vectorCollectionName } from '../config/constants';
 
 const documentsPath = process.env.DOCUMENTS_PATH || path.resolve(process.cwd(), 'documents');
 
@@ -57,12 +58,12 @@ async function storeEmbeddings(documents: { name: string; chunks: string[] }[]):
 
 	try {
 		// delete existing collection
-		if (await chromaClient.getOrCreateCollection({ name: 'SchedulrAI-KB' })) {
-			await chromaClient.deleteCollection({ name: 'SchedulrAI-KB' });
+		if (await chromaClient.getOrCreateCollection({ name: vectorCollectionName })) {
+			await chromaClient.deleteCollection({ name: vectorCollectionName });
 		}
 
 		const collection = await chromaClient.createCollection({
-			name: 'SchedulrAI-KB',
+			name: vectorCollectionName,
 			embeddingFunction: embedder,
 		});
 

--- a/backend/src/tests/controllers/authController.test.ts
+++ b/backend/src/tests/controllers/authController.test.ts
@@ -172,7 +172,7 @@ describe('Auth Controller', () => {
 
 			expect(mockResponse.status).toHaveBeenCalledWith(500);
 			expect(mockResponse.json).toHaveBeenCalledWith({
-				message: 'Registration failed',
+				message: 'Failed to create the user',
 			});
 		});
 

--- a/backend/src/tests/controllers/pipelineController.test.ts
+++ b/backend/src/tests/controllers/pipelineController.test.ts
@@ -3,6 +3,7 @@ import PipelineController from '../../controllers/pipelineController';
 import RAGPipeline from '../../services/pipelineServices';
 import logger from '../../utils/logger';
 import { EventEmitter } from 'events';
+import { vectorCollectionName } from '../../config/constants';
 
 // Mock the dependencies
 jest.mock('../../services/pipelineServices');
@@ -409,7 +410,7 @@ describe('PipelineController', () => {
 					topP: 0.9,
 				},
 				{
-					collectionName: 'SchedulrAI-KB',
+					collectionName: vectorCollectionName,
 					url: expectedChromaUrl,
 					clientParams: {
 						auth: {

--- a/backend/src/tests/routes/knowledgeRoutes.test.ts
+++ b/backend/src/tests/routes/knowledgeRoutes.test.ts
@@ -1,10 +1,10 @@
 import request from 'supertest';
 import express from 'express';
 import knowledgeRoutes from '../../routes/knowledgeRoutes';
-import { indexDocuments } from '../../services/documentServices';
 import { getUserById, updateUser } from '../../services/dbServices';
-import { createDocument, deleteDocument, listDocuments } from '../../services/documentServices';
+import { createDocument, deleteDocument, listDocuments, indexDocuments } from '../../services/documentServices';
 import { resetChromaCollection } from '../../services/chromaServices';
+import { vectorCollectionName } from '../../config/constants';
 
 jest.mock('../../services/documentServices');
 jest.mock('../../services/dbServices');
@@ -106,7 +106,7 @@ describe('Knowledge Base Routes', () => {
 			expect(updateUser).toHaveBeenCalledWith('user1', {
 				userSettings: { userSettingsKB: [] },
 			});
-			expect(resetChromaCollection).toHaveBeenCalledWith('SchedulrAI-KB');
+			expect(resetChromaCollection).toHaveBeenCalledWith(vectorCollectionName);
 		});
 
 		it('should return 404 when user is not found', async () => {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,8 +6,10 @@ services:
         env_file: .env
         environment:
             - IS_PERSISTENT=TRUE
+            - ANONYMIZED_TELEMETRY=False
         networks:
             - schedulrai
+        restart: unless-stopped
         container_name: chroma
         volumes:
             - .chroma_volume:/chroma/chroma
@@ -19,7 +21,7 @@ services:
         container_name: backend
         pull_policy: always
         tty: true
-        restart: always
+        restart: unless-stopped
         networks:
             - schedulrai
         env_file: .env
@@ -37,6 +39,7 @@ services:
         ports:
             - '80:80'
         container_name: frontend
+        restart: unless-stopped
         networks:
             - schedulrai
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         env_file: .env
         environment:
             - IS_PERSISTENT=TRUE
+            - ANONYMIZED_TELEMETRY=False
+        restart: unless-stopped
         networks:
             - schedulrai
         container_name: chroma
@@ -21,7 +23,7 @@ services:
         container_name: backend
         pull_policy: always
         tty: true
-        restart: always
+        restart: unless-stopped
         networks:
             - schedulrai
         env_file: .env
@@ -40,6 +42,7 @@ services:
             dockerfile: Dockerfile.frontend
         ports:
             - '80:80'
+        restart: unless-stopped
         container_name: frontend
         networks:
             - schedulrai


### PR DESCRIPTION
###  Trigger for initial creation of vector collection for RAG
* Creating new user now triggers creation of chroma vector collection of knowledge, if one does not exist already
* Triggered in background and non-blocking to the rest of the process


Centralization of vector collection name:

* `backend/src/config/constants.ts` Added `vectorCollectionName` constant.
* Updated various files to use `vectorCollectionName` instead of hardcoding 'SchedulrAI-KB':
  * Test files

Improved error messages:

* `backend/src/controllers/authController.ts`: Updated error message to 'Failed to create the user'.
* `backend/src/tests/controllers/authController.test.ts`: Updated corresponding test to match the new error message.

Docker configuration updates:

* `docker-compose.prod.yml` and `docker-compose.yml`: Added `restart: unless-stopped` to services for better container management and added `ANONYMIZED_TELEMETRY=False` to the environment variables.