### PR TITLE
fix(backend): enhance google users username logic, move vector collection check to background

### DIFF
--- a/backend/src/middlewares/passport.ts
+++ b/backend/src/middlewares/passport.ts
@@ -71,9 +71,16 @@ passport.use(
 					return done(null, updatedUsers[0]);
 				}
 
-				const constructedUsername = `${profile.name.givenName.toLowerCase()}${profile.name.familyName
-					.charAt(0)
-					.toLowerCase()}${profile.id.slice(-2)}`;
+				/**
+				 * Constructs a unique username by combining:
+				 * - User's given name (lowercase) or 'user' if not available
+				 * - First character of family name (lowercase) or 'x' if not available
+				 * - Last 2 characters of the profile ID
+				 */
+				const constructedUsername = `${profile.name?.givenName?.toLowerCase() || 'user'}${
+					profile.name?.familyName?.charAt(0)?.toLowerCase() || 'x'
+				}${profile.id.slice(-2)}`;
+
 				// Create new user
 				const newUserObj = {
 					username: constructedUsername,

--- a/backend/src/tests/routes/authRoutes.test.ts
+++ b/backend/src/tests/routes/authRoutes.test.ts
@@ -352,6 +352,40 @@ describe('Authentication Routes', () => {
 			});
 		});
 
+		it('should handle Google User creation when family name or given name is missing', async () => {
+			const mockGoogleProfile = {
+				id: 'google123',
+				emails: [{ value: 'noNames@gmail.com' }],
+				name: {
+					givenName: null,
+					familyName: null,
+				},
+			};
+
+			const newUser = {
+				...mockUser,
+				googleId: mockGoogleProfile.id,
+				googleAccessToken: mockGoogleTokens.accessToken,
+				googleRefreshToken: mockGoogleTokens.refreshToken,
+			};
+
+			(getUserByGoogleIdOrEmail as jest.Mock).mockResolvedValue(null);
+			(createUser as jest.Mock).mockResolvedValue(newUser);
+
+			await new Promise<void>((resolve) => {
+				(passport as any)._strategies.google._verify(
+					mockGoogleTokens.accessToken,
+					mockGoogleTokens.refreshToken,
+					mockGoogleProfile,
+					(err: Error, user: any) => {
+						expect(err).toBeNull();
+						expect(user).toEqual(newUser);
+						resolve();
+					}
+				);
+			});
+		});
+
 		it('should handle successful Google authentication for existing user', async () => {
 			const existingUser = {
 				...mockUser,

--- a/backend/src/tests/services/dbServices.test.ts
+++ b/backend/src/tests/services/dbServices.test.ts
@@ -67,8 +67,12 @@ describe('Database Services', () => {
 		let user;
 
 		beforeEach(() => {
-			// Reset mocks before each test
+			jest.useFakeTimers();
 			jest.clearAllMocks();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
 		});
 
 		beforeAll(async () => {
@@ -90,6 +94,10 @@ describe('Database Services', () => {
 			});
 
 			expect(newUser).toBeDefined();
+
+			// Run all pending timers and promises
+			await jest.runAllTimersAsync();
+
 			expect(getChromaCollection).toHaveBeenCalled();
 			expect(indexDocuments).not.toHaveBeenCalled();
 			expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Vector collection:'));
@@ -98,6 +106,7 @@ describe('Database Services', () => {
 		it('should create a user and handle missing vector collection', async () => {
 			// Mock failed vector collection retrieval
 			(getChromaCollection as jest.Mock).mockRejectedValueOnce(new Error('Collection not found'));
+			(indexDocuments as jest.Mock).mockResolvedValueOnce(true);
 
 			const newUser = await createUser({
 				username: 'novectoruser',
@@ -106,6 +115,10 @@ describe('Database Services', () => {
 			});
 
 			expect(newUser).toBeDefined();
+
+			// Run all pending timers and promises
+			await jest.runAllTimersAsync();
+
 			expect(getChromaCollection).toHaveBeenCalled();
 			expect(indexDocuments).toHaveBeenCalled();
 			expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error getting vector collection'));


### PR DESCRIPTION
This pull request fixes edge case where google user would not have first name or family name, or it is failed to parse,


### Google User name:
- added fallback to 'user' for givenName
- added fallback to 'x' for family name


### Vector Collection checks
- Check and initial index now fully background - with `setImmediate`
  - Fire and forget from `createUser` perspective

- Adjust unit test
- Tested on Mac