### PR TITLE
fix(backend): enhance resetChromaCollection to handle non-existent collections gracefully

### DIFF
--- a/backend/src/services/chromaServices.ts
+++ b/backend/src/services/chromaServices.ts
@@ -39,9 +39,12 @@ export async function getChromaCollection(collectionName: string) {
 }
 
 export async function createChromaCollection(collectionName: string) {
+	const chromaClient = getChromaClient();
+	const embeddingFunction = getEmbeddingFunction();
+
 	try {
-		const chromaClient = getChromaClient();
-		const embeddingFunction = getEmbeddingFunction();
+		// Will silently continue if collection doesn't exist
+		await resetChromaCollection(collectionName);
 
 		return await chromaClient.createCollection({
 			name: collectionName,
@@ -59,7 +62,12 @@ export async function resetChromaCollection(collectionName: string) {
 		await chromaClient.deleteCollection({ name: collectionName });
 		logger.info(`Collection ${collectionName} deleted successfully`);
 		return { success: true };
-	} catch (error) {
+	} catch (error: any) {
+		// Ignore if collection doesn't exist
+		if (error.message?.includes('does not exist')) {
+			logger.info(`Collection ${collectionName} does not exist, skipping deletion`);
+			return { success: true };
+		}
 		logger.error('Error resetting Chroma collection:', error);
 		throw error;
 	}

--- a/backend/src/tests/services/chromaServices.test.ts
+++ b/backend/src/tests/services/chromaServices.test.ts
@@ -140,5 +140,23 @@ describe('chromaServices', () => {
 			mockDeleteCollection.mockRejectedValue(new Error('Deletion failed'));
 			await expect(resetChromaCollection('test')).rejects.toThrow('Deletion failed');
 		});
+
+		it('should handle non-existent collection gracefully', async () => {
+			const collectionName = 'nonExistentCollection';
+			const nonExistentError = new Error('Collection nonExistentCollection does not exist');
+			mockDeleteCollection.mockRejectedValue(nonExistentError);
+
+			const result = await resetChromaCollection(collectionName);
+
+			expect(ChromaClient).toHaveBeenCalledWith({
+				path: 'http://localhost:8000',
+				auth: {
+					provider: 'basic',
+					credentials: 'test-credentials',
+				},
+			});
+			expect(mockDeleteCollection).toHaveBeenCalledWith({ name: collectionName });
+			expect(result).toEqual({ success: true });
+		});
 	});
 });

--- a/backend/src/tests/services/documentServices.test.ts
+++ b/backend/src/tests/services/documentServices.test.ts
@@ -57,7 +57,7 @@ describe('Document Indexing Workflow', () => {
 			heartbeat: jest.fn(),
 			getCollection: jest.fn().mockResolvedValue(mockCollection),
 			createCollection: jest.fn().mockResolvedValue(mockCollection),
-			deleteCollection: jest.fn(),
+			deleteCollection: jest.fn().mockResolvedValue(void 0),
 		}));
 	});
 
@@ -71,6 +71,7 @@ describe('Document Indexing Workflow', () => {
 		(ChromaClient as jest.Mock).mockImplementation(() => ({
 			getCollection: jest.fn().mockResolvedValue(mockCollection),
 			createCollection: jest.fn().mockResolvedValue(mockCollection),
+			deleteCollection: jest.fn().mockResolvedValue(void 0),
 		}));
 
 		await indexDocuments();
@@ -92,6 +93,7 @@ describe('Document Indexing Workflow', () => {
 
 		(ChromaClient as jest.Mock).mockImplementation(() => ({
 			createCollection: jest.fn().mockResolvedValue(mockCollection),
+			deleteCollection: jest.fn().mockResolvedValue(void 0),
 		}));
 
 		await expect(indexDocuments()).rejects.toThrow('Directory read failed');
@@ -107,6 +109,7 @@ describe('Document Indexing Workflow', () => {
 		(ChromaClient as jest.Mock).mockImplementation(() => ({
 			getCollection: jest.fn().mockResolvedValue(mockCollection),
 			createCollection: jest.fn().mockResolvedValue(mockCollection),
+			deleteCollection: jest.fn().mockResolvedValue(void 0),
 		}));
 
 		await expect(indexDocuments()).rejects.toThrow('Storage failed');


### PR DESCRIPTION
- Fix backend error handling in resetChromaCollection
  - Now skips deletion if the collection doesn’t exist, preventing unnecessary errors.
  - Adjust test